### PR TITLE
Getting Trivy Scan results in JSON

### DIFF
--- a/cd_pipeline.jenkinsfile
+++ b/cd_pipeline.jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
         stage('Docker Image Trivy Scan') { 
             steps {
                 // sh "trivy image --exit-code 1 --severity CRITICAL pkuma343/myimage:${env.BUILD_NUMBER}"		
-                sh "trivy image --exit-code 0 yeskay16/devsecopsapp:$CI_BUILD_NUMBER"
+                sh "trivy image -f json -o results.json --exit-code 0 yeskay16/devsecopsapp:$CI_BUILD_NUMBER"
             }
         }
 


### PR DESCRIPTION
Afterwards we may use JQ editor to filter the number of Critical/High vulns.
Subsequently we can put a threshold number where the build should fail.